### PR TITLE
Moving to Akka.Streams 1.3.5

### DIFF
--- a/examples/SimpleConsumer/SimpleConsumer.csproj
+++ b/examples/SimpleConsumer/SimpleConsumer.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="0.11.0-ci-48" />
+    <PackageReference Include="Confluent.Kafka" Version="0.11.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/SimpleProducer/SimpleProducer.csproj
+++ b/examples/SimpleProducer/SimpleProducer.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="0.11.0-ci-48" />
+    <PackageReference Include="Confluent.Kafka" Version="0.11.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Akka.Streams.Kafka.Tests/Akka.Streams.Kafka.Tests.csproj
+++ b/src/Akka.Streams.Kafka.Tests/Akka.Streams.Kafka.Tests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.Streams.TestKit" Version="1.3.0" />
-    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.3.0" />
+    <PackageReference Include="Akka.Streams.TestKit" Version="1.3.5" />
+    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.3.5" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.0-*" />
@@ -16,6 +16,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Akka.Streams.Kafka\Akka.Streams.Kafka.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/src/Akka.Streams.Kafka/Akka.Streams.Kafka.csproj
+++ b/src/Akka.Streams.Kafka/Akka.Streams.Kafka.csproj
@@ -21,9 +21,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.Streams" Version="1.3.0" />
-    <PackageReference Include="Confluent.Kafka" Version="0.11.0-ci-48" />
-    <PackageReference Include="MessagePack" Version="1.6.1" />
+    <PackageReference Include="Akka.Streams" Version="1.3.5" />
+    <PackageReference Include="Confluent.Kafka" Version="0.11.3" />
+    <PackageReference Include="MessagePack" Version="1.7.3.4" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
 

--- a/src/Akka.Streams.Kafka/Dsl/Consumer.cs
+++ b/src/Akka.Streams.Kafka/Dsl/Consumer.cs
@@ -14,12 +14,12 @@ namespace Akka.Streams.Kafka.Dsl
     {
         public static Source<Message<K, V>, Task> PlainSource<K, V>(ConsumerSettings<K, V> settings, ISubscription subscription)
         {
-            return Source.FromGraph(new KafkaSourceStage<K, V, Message<K, V>>(settings, subscription));
+            return Source.FromGraph(new KafkaSourceStage<K, V>(settings, subscription));
         }
 
         public static Source<CommittableMessage<K, V>, Task> CommittableSource<K, V>(ConsumerSettings<K, V> settings, ISubscription subscription)
         {
-            return Source.FromGraph(new CommittableConsumerStage<K, V, CommittableMessage<K, V>>(settings, subscription));
+            return Source.FromGraph(new CommittableConsumerStage<K, V>(settings, subscription));
         }
     }
 }

--- a/src/Akka.Streams.Kafka/Stages/ProducerStage.cs
+++ b/src/Akka.Streams.Kafka/Stages/ProducerStage.cs
@@ -36,8 +36,8 @@ namespace Akka.Streams.Kafka.Stages
         private Action<ProduceRecord<K, V>> _sendToProducer;
         private readonly ProducerSettings<K, V> _settings;
 
-        private Inlet In { get; }
-        private Outlet Out { get; }
+        private Inlet<ProduceRecord<K, V>> In { get; }
+        private Outlet<Task<Message<K, V>>> Out { get; }
 
         public ProducerStageLogic(ProducerStage<K, V> stage, Attributes attributes) : base(stage.Shape)
         {


### PR DESCRIPTION
Updating dependencies: Akka.Streams 1.3.5, Confluent.Kafka 0.11.3,
MessagePack 1.7.3.4.
Also updating stages to support type-safe Akka.Streams API changes akkadotnet/akka.net/pull/3237.

I've decided to remove "Msg" generic type from stages, because it's type was hardcoded in buffer collection.